### PR TITLE
Startpage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 test.js
 test.json
 node_modules/
+
+# sample html files
+examples/
+
+# packaged distributions
+*.zip

--- a/README.md
+++ b/README.md
@@ -6,20 +6,20 @@
 
 ## Description
 
-The UnSponsored Chrome Extension removes sponsored search results from Google Search.
+The UnSponsored Chrome Extension removes sponsored search results from Google Search and Startpage.
 
 ## Installation
 
 1. Download the extension files from the [GitHub repository](https://github.com/dumbross/UnSponsored).
 2. Unzip the downloaded folder.
-3. Open Google Chrome.
+3. Open Google Chrome / Brave.
 4. Go to `chrome://extensions/`.
 5. Enable **Developer mode** in the top right corner.
 6. Click on **Load unpacked** and select the unzipped folder.
 
 ## Usage
 
-Once installed, perform a Google Search, and sponsored results will be hidden automatically. Open the Dev menu and check console to see how many links where hidden.
+Once installed, perform a search in Google Search or Startpage, and sponsored results will be hidden automatically. Open the Dev menu and check console to see how many links where hidden.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ to watch my people suffer.
 
 ## Version History
 
+### Version 1.7 (May 17, 2025)
+
+- Added support for blocking sponsored content on Startpage.com
+
 ### Version 1.6 (March 05, 2025)
 
 - Added new flag to identify and hide new type of sponsored result - mapview shortlist result. 

--- a/UnSponsored.js
+++ b/UnSponsored.js
@@ -35,7 +35,7 @@ function hideSponsoredElements() {
   });
 
   // Hides sponsored content containers in top and bottom areas
-  let adDivs = document.querySelectorAll('#gcsa-top, #gcsa-bottom');
+  let adDivs = document.querySelectorAll('#gcsa-top, #gcsa-bottom, #gcsa-aylf-sidebar');
   adDivs.forEach(element => {
     element.dataset.originalDisplay = window.getComputedStyle(element).display;
     element.style.display = 'none';

--- a/UnSponsored.js
+++ b/UnSponsored.js
@@ -14,12 +14,15 @@ function hideSponsoredElements() {
   // Hides text ads that appear at the top and bottom of search results
   let textAdElements = document.querySelectorAll('[data-text-ad="1"]');
   textAdElements.forEach(element => {
+    // Store computed display value before hiding
+    element.dataset.originalDisplay = window.getComputedStyle(element).display;
     element.style.display = 'none';
   });
 
   // Hides "Sponsored" links that appear in search results
   let isAdElements = document.querySelectorAll('[data-is-ad="1"]');
   isAdElements.forEach(element => {
+    element.dataset.originalDisplay = window.getComputedStyle(element).display;
     element.style.display = 'none';
   });
 
@@ -27,12 +30,14 @@ function hideSponsoredElements() {
   // Hides sponsored search results marked with data-ad-container
   let startpageAdContainers = document.querySelectorAll('[data-ad-container="1"]');
   startpageAdContainers.forEach(element => {
+    element.dataset.originalDisplay = window.getComputedStyle(element).display;
     element.style.display = 'none';
   });
 
-  // Hides sponsored content containers in top, bottom and sidebar areas
-  let adDivs = document.querySelectorAll('#gcsa-top, #gcsa-bottom, #gcsa-aylf-sidebar');
+  // Hides sponsored content containers in top and bottom areas
+  let adDivs = document.querySelectorAll('#gcsa-top, #gcsa-bottom');
   adDivs.forEach(element => {
+    element.dataset.originalDisplay = window.getComputedStyle(element).display;
     element.style.display = 'none';
   });
 
@@ -54,23 +59,23 @@ function showSponsoredElements() {
   // Google ad selectors
   let textAdElements = document.querySelectorAll('[data-text-ad="1"]');
   textAdElements.forEach(element => {
-    element.style.display = 'block';
+    element.style.display = element.dataset.originalDisplay || '';
   });
 
   let isAdElements = document.querySelectorAll('[data-is-ad="1"]');
   isAdElements.forEach(element => {
-    element.style.display = 'block';
+    element.style.display = element.dataset.originalDisplay || '';
   });
 
   // Startpage ad selectors
   let startpageAdContainers = document.querySelectorAll('[data-ad-container="1"]');
   startpageAdContainers.forEach(element => {
-    element.style.display = 'block';
+    element.style.display = element.dataset.originalDisplay || '';
   });
 
-  let adDivs = document.querySelectorAll('#gcsa-top, #gcsa-bottom, #gcsa-aylf-sidebar');
+  let adDivs = document.querySelectorAll('#gcsa-top, #gcsa-bottom');
   adDivs.forEach(element => {
-    element.style.display = 'block';
+    element.style.display = element.dataset.originalDisplay || '';
   });
 
   console.log('[Google] Number of [data-text-ad="1"] elements shown:', textAdElements.length);

--- a/UnSponsored.js
+++ b/UnSponsored.js
@@ -10,28 +10,36 @@ chrome.storage.sync.get('enabled', function (data) {
 });
 
 function hideSponsoredElements() {
-  // Select elements with data-text-ad="1"
+  // Google ad selectors
+  // Hides text ads that appear at the top and bottom of search results
   let textAdElements = document.querySelectorAll('[data-text-ad="1"]');
   textAdElements.forEach(element => {
     element.style.display = 'none';
   });
 
-  // Select elements with data-is-ad="1"    <---------------------------This attr will find sponsored links in mapview short list
+  // Hides "Sponsored" links that appear in search results
   let isAdElements = document.querySelectorAll('[data-is-ad="1"]');
   isAdElements.forEach(element => {
     element.style.display = 'none';
   });
 
-
-  // Select elements with data-ad-container="1" (startpage sponsored ads)
-  let adContainerElements = document.querySelectorAll('[data-ad-container="1"]');
-  isAdElements.forEach(element => {
+  // Startpage ad selectors
+  // Hides sponsored search results marked with data-ad-container
+  let startpageAdContainers = document.querySelectorAll('[data-ad-container="1"]');
+  startpageAdContainers.forEach(element => {
     element.style.display = 'none';
   });
 
-  console.log('Number of text ad elements hidden:', textAdElements.length);
-  console.log('Number of is-ad elements hidden:', isAdElements.length);
-  console.log('Number of ad-container elements hidden:', adContainerElements.length);
+  // Hides sponsored content containers in top, bottom and sidebar areas
+  let adDivs = document.querySelectorAll('#gcsa-top, #gcsa-bottom, #gcsa-aylf-sidebar');
+  adDivs.forEach(element => {
+    element.style.display = 'none';
+  });
+
+  console.log('[Google] Number of [data-text-ad="1"] elements hidden:', textAdElements.length);
+  console.log('[Google] Number of [data-is-ad="1"] elements hidden:', isAdElements.length);
+  console.log('[Startpage] Number of [data-ad-container="1"] elements hidden:', startpageAdContainers.length);
+  console.log('[Startpage] Number of gcsa-* container elements hidden:', adDivs.length);
 }
 
 chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
@@ -43,25 +51,30 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
 });
 
 function showSponsoredElements() {
-  // Select elements with data-text-ad="1"
+  // Google ad selectors
   let textAdElements = document.querySelectorAll('[data-text-ad="1"]');
   textAdElements.forEach(element => {
-    element.style.display = 'block'; // Assuming "block" is the default display for these elements
+    element.style.display = 'block';
   });
 
-  // Select elements with data-is-ad="1"
   let isAdElements = document.querySelectorAll('[data-is-ad="1"]');
   isAdElements.forEach(element => {
     element.style.display = 'block';
   });
 
-  // Select elements with data-ad-container="1" (startpage sponsored ads)
-  let adContainerElements = document.querySelectorAll('[data-ad-container="1"]');
-  isAdElements.forEach(element => {
+  // Startpage ad selectors
+  let startpageAdContainers = document.querySelectorAll('[data-ad-container="1"]');
+  startpageAdContainers.forEach(element => {
     element.style.display = 'block';
   });
 
-  console.log('Number of text ad elements shown:', textAdElements.length);
-  console.log('Number of is-ad elements shown:', isAdElements.length);
-  console.log('Number of ad-container elements shown:', adContainerElements.length);
+  let adDivs = document.querySelectorAll('#gcsa-top, #gcsa-bottom, #gcsa-aylf-sidebar');
+  adDivs.forEach(element => {
+    element.style.display = 'block';
+  });
+
+  console.log('[Google] Number of [data-text-ad="1"] elements shown:', textAdElements.length);
+  console.log('[Google] Number of [data-is-ad="1"] elements shown:', isAdElements.length);
+  console.log('[Startpage] Number of [data-ad-container="1"] elements shown:', startpageAdContainers.length);
+  console.log('[Startpage] Number of gcsa-* container elements shown:', adDivs.length);
 }

--- a/UnSponsored.js
+++ b/UnSponsored.js
@@ -1,4 +1,4 @@
-chrome.storage.sync.get('enabled', function(data) {
+chrome.storage.sync.get('enabled', function (data) {
   var isEnabled = data.enabled;
   if (isEnabled === undefined) {
     isEnabled = true; // Default to true if the value is not set
@@ -22,11 +22,19 @@ function hideSponsoredElements() {
     element.style.display = 'none';
   });
 
+
+  // Select elements with data-ad-container="1" (startpage sponsored ads)
+  let adContainerElements = document.querySelectorAll('[data-ad-container="1"]');
+  isAdElements.forEach(element => {
+    element.style.display = 'none';
+  });
+
   console.log('Number of text ad elements hidden:', textAdElements.length);
   console.log('Number of is-ad elements hidden:', isAdElements.length);
+  console.log('Number of ad-container elements hidden:', adContainerElements.length);
 }
 
-chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
+chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
   if (request.enabled) {
     hideSponsoredElements();
   } else {
@@ -47,6 +55,13 @@ function showSponsoredElements() {
     element.style.display = 'block';
   });
 
+  // Select elements with data-ad-container="1" (startpage sponsored ads)
+  let adContainerElements = document.querySelectorAll('[data-ad-container="1"]');
+  isAdElements.forEach(element => {
+    element.style.display = 'block';
+  });
+
   console.log('Number of text ad elements shown:', textAdElements.length);
   console.log('Number of is-ad elements shown:', isAdElements.length);
+  console.log('Number of ad-container elements shown:', adContainerElements.length);
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,35 +1,39 @@
 {
-    "manifest_version": 4,
-    "name": "UnSponsored",
-    "version": "1.6",
-    "description": "Hide sponsored content on web pages.",
-    "action": {
-      "default_popup": "popup.html"      
-    },
-    "permissions": [
-      "storage",
-      "activeTab"
-    ],
-    "content_scripts": [
-      {
-        "matches": ["https://www.google.com/*"],
-        "js": ["UnSponsored.js"]
-      }
-    ],
-    "browser_action": {
-      "default_icon": {
-        "16": "icons/icon16.png",
-        "48": "icons/icon48.png",
-        "128": "icons/icon128.png"
-      }
-    },
-    "icons": {
+  "manifest_version": 4,
+  "name": "UnSponsored",
+  "version": "1.7",
+  "description": "Hide sponsored content on web pages.",
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "permissions": [
+    "storage",
+    "activeTab"
+  ],
+  "content_scripts": [
+    {
+      "matches": [
+        "https://www.google.com/*",
+        "https://www.startpage.com/*"
+      ],
+      "js": [
+        "UnSponsored.js"
+      ]
+    }
+  ],
+  "browser_action": {
+    "default_icon": {
       "16": "icons/icon16.png",
       "48": "icons/icon48.png",
       "128": "icons/icon128.png"
-    },
-    "options_ui": {
-        "page": "popup.html"
     }
+  },
+  "icons": {
+    "16": "icons/icon16.png",
+    "48": "icons/icon48.png",
+    "128": "icons/icon128.png"
+  },
+  "options_ui": {
+    "page": "popup.html"
   }
-  
+}


### PR DESCRIPTION
# Add Startpage.com Support

## Changes
- Added support for blocking sponsored content on Startpage.com search results
- Enhanced logging to id which search engine's ads are being blocked and which attributes are being used to select them
- Improved element restoration by preserving original display values

## Technical Details
- Added new selectors to target Startpage-specific ad elements:
  - `[data-ad-container="1"]` for sponsored search results
  - `#gcsa-top, #gcsa-bottom, #gcsa-aylf-sidebar` for sponsored content containers
- Uses `window.getComputedStyle()` to properly store original display values (original implementation would not restore sponsored results on Startpage)
- Consistent behavior between Google and Startpage implementations

## Testing
Tested on:
- Brave browser (Chromium)
- Google Search results
- Startpage.com search results
- Extension toggle functionality (hide/show)
- Browser console logging

## Next steps:
- The rest of the search engines!